### PR TITLE
Cross build for sbt 0.13 and 1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,11 @@ name := "youi-plugin"
 organization := "io.youi"
 version := "1.0.1"
 sbtPlugin := true
-scalaVersion := "2.10.6"
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")
+crossSbtVersions := Vector("0.13.16", "1.0.4")
+// Workaround for https://github.com/sbt/sbt/issues/3393
+// This will be solved in sbt 0.13.17
+libraryDependencies += {
+  val currentSbtVersion = (sbtBinaryVersion in pluginCrossBuild).value
+  Defaults.sbtPluginExtra("org.scala-js" % "sbt-scalajs" % "0.6.21", currentSbtVersion, (scalaBinaryVersion in update).value)
+}
 libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")

--- a/src/main/scala/io/youi/plugin/CrossApplication.scala
+++ b/src/main/scala/io/youi/plugin/CrossApplication.scala
@@ -62,7 +62,7 @@ object CrossApplication {
     val methodName = c.macroApplication.symbol.name
 
     // trim is not strictly correct, but macros don't expose the API necessary
-    def processName(n: Name): String = n.decoded.trim
+    def processName(n: Name): String = n.decodedName.toString.trim
 
     def enclosingVal(trees: List[c.Tree]): String = trees match {
       case vd @ ValDef(_, name, _, _) :: ts =>
@@ -76,7 +76,7 @@ object CrossApplication {
       case Block(_, _) :: DefDef(mods, name, _, _, _, _) :: xs if mods.hasFlag(Flag.LAZY) =>
         processName(name)
       case _ =>
-        c.error(c.enclosingPosition, invalidEnclosingTree(methodName.decoded))
+        c.error(c.enclosingPosition, invalidEnclosingTree(methodName.decodedName.toString))
         "<error>"
     }
 

--- a/src/main/scala/io/youi/plugin/PartialCrossApplication.scala
+++ b/src/main/scala/io/youi/plugin/PartialCrossApplication.scala
@@ -20,8 +20,8 @@ class PartialCrossApplication(id: String) {
       youiInclude := true
     )
     CrossApplication(
-      js = Project(s"${id}JS", new File(dir, "js"), settings = defaultSettings),
-      jvm = Project(s"${id}JVM", new File(dir, "jvm"), settings = defaultSettings)
+      js = Project(s"${id}JS", new File(dir, "js")).settings(defaultSettings),
+      jvm = Project(s"${id}JVM", new File(dir, "jvm")).settings(defaultSettings)
     ).settings(
       // Add youi-app
       libraryDependencies ++= (if (youiInclude.value) {


### PR DESCRIPTION
- Crossbuilding
- updated sbt-sonatype and sbt-pgp to latest version
- addSbtVersion(...) cannot be used for a sbt bug solved and merged ready for 0.13.17 so I used a workaround until 0.13.17 is out.

Thank you for your wonderful open source work... It is true that you are not reinventing the wheel but building space ships!!! I hope you will get the deserved visibility in the scala world.